### PR TITLE
Support for distribution files having spaces in name

### DIFF
--- a/lib/File/ShareDir/Install.pm
+++ b/lib/File/ShareDir/Install.pm
@@ -162,7 +162,8 @@ CODE
 
         my $files = {};
         _scan_share_dir( $files, $idir, $dir, $def );
-        @cmds = $self->split_command( $pm_to_blib, %$files );
+        @cmds = $self->split_command( $pm_to_blib,
+            map { ($self->quote_literal($_) => $self->quote_literal($files->{$_})) } sort keys %$files );
     }
 
     my $r = join '', map { "\t\$(NOECHO) $_\n" } @cmds;

--- a/t/10_makefile.t
+++ b/t/10_makefile.t
@@ -8,7 +8,7 @@ use ExtUtils::MakeMaker;
 
 plan skip_all => 'This test requires a Makefile in the built distribution' if not -f 'Makefile';
 
-plan tests => 16;
+plan tests => 19;
 
 my $FILE = "test-$$-Makefile";
 rmtree( [ "tlib-$$", "troot-$$" ], 0, 0 );
@@ -51,6 +51,7 @@ sub slurp
 ok( -f $FILE, "Created $FILE" );
 my $content = slurp $FILE;
 ok( $content =~ m(t.share.honk.+share.dist...DISTNAME..honk), "Shared by dist" );
+ok( $content =~ m(t.share.hello world.+share.dist...DISTNAME..hello world), "Shared by dist" );
 ok( $content =~ m(t.module.bonk.+share.module.My-Test.bonk), "Shared by module" );
 ok( $content =~ m(t.module.again.+share.module.My-Test.again), "Shared by module again" );
 ok( $content =~ m(t.module.deeper.bonk.+share.module.My-Test.deeper.bonk), "Shared by module in subdirectory" );
@@ -61,6 +62,7 @@ ok( $content !~ m(t.share.\.something), "Don't share dot files" );
 mysystem( $Config{make}, '-f', $FILE );
 my $TOP = "tlib-$$/lib/auto/share";
 ok( -f "$TOP/dist/File-ShareDir-Install/honk", "Copied to blib for dist" );
+ok( -f "$TOP/dist/File-ShareDir-Install/hello world", "Copied to blib for dist" );
 ok( -f "$TOP/module/My-Test/bonk", "Copied to blib for module" );
 ok( -f "$TOP/module/My-Test/again", "Copied to blib for module again" );
 ok( -f "$TOP/module/My-Test/deeper/bonk", "Copied to blib for module, in subdir" );
@@ -81,6 +83,7 @@ else {
     $TOP = "$1/auto/share";
     $TOP =~ s/\$\(SITEPREFIX\)/troot-$$/;
     ok( -f "$TOP/dist/File-ShareDir-Install/honk", "Copied to blib for dist" );
+    ok( -f "$TOP/dist/File-ShareDir-Install/hello world", "Copied to blib for dist" );
     ok( -f "$TOP/module/My-Test/bonk", "Copied to blib for module" );
     ok( -f "$TOP/module/My-Test/again", "Copied to blib for module again" );
     ok( -f "$TOP/module/My-Test/deeper/bonk", "Copied to blib for module, in subdir" );


### PR DESCRIPTION
Address #1 again.

Currently if share files contain space in their filenames, File::ShareDir::Install will emit an invalid Makefile:
```
config::
	$(NOECHO) $(ABSPERLRUN) -MExtUtils::Install -e 'pm_to_blib({@ARGV}, '\''$(INST_LIB)'\'')' -- \
	  t/share/honk $(INST_LIB)/auto/share/dist/$(DISTNAME)/honk \
	  t/share/hello world $(INST_LIB)/auto/share/dist/$(DISTNAME)/hello world
```

This PR fixes this by using the quote_literal method.
See also https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/blob/dcefb438ff2741e792ba8a52292abfac3e50cc54/lib/ExtUtils/MM_Unix.pm#L3082-L3083